### PR TITLE
Torna o header transparente (Glass-looking)

### DIFF
--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -2,7 +2,8 @@
 import styled, { css } from 'styled-components';
 
 export const Container = styled.div`
-  background: ${({ theme }) => theme.header};
+  background: ${({ theme }) => `${theme.header}CC`};
+  backdrop-filter: blur(10px);
   max-width: 100%;
 
   position: sticky;
@@ -15,6 +16,7 @@ export const Container = styled.div`
         position: absolute;
 
         background:
+        backdrop-filter: none;
 
         z-index: 10;
         background: transparent;


### PR DESCRIPTION
Deixa o header transparente, com o blur aplicado.
###### OBS.: Mantêm a integração com o context do tema atual.