### PR TITLE
Corrige blur sempre ativo no Header

### DIFF
--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -15,7 +15,7 @@ export const Container = styled.div`
       @media (min-width: 1024px) {
         position: absolute;
 
-        background:
+        background: none;
         backdrop-filter: none;
 
         z-index: 10;
@@ -24,7 +24,7 @@ export const Container = styled.div`
 
         border: none !important;
       }
-  `};
+    `};
 `;
 
 export const Content = styled.div`


### PR DESCRIPTION
Corrige bug visual em que o desfoque do glass-looking (#1) estava sempre ativo no header da página.

![image](https://user-images.githubusercontent.com/52381662/108118496-30fc5c00-707d-11eb-81fc-616be1806314.png)

O erro foi ocasionado por conta de uma propriedade CSS incompleta que afetava a execução da propriedade usada para desabilitar o  `backdrop-filter`. #