### PR TITLE
Adicionar ícone do Instagram ao rodapé

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,8 +1,7 @@
 /* eslint-disable object-curly-newline */
 import { useContext } from 'react';
 import { ThemeContext } from 'styled-components';
-import Link from 'next/link';
-import { AiFillGithub as GithubIcon } from 'react-icons/ai';
+import { AiFillGithub as GithubIcon, AiOutlineInstagram as InstagramIcon } from 'react-icons/ai';
 import { FiMail as EmailIcon } from 'react-icons/fi';
 
 import { darkTheme } from '../../styles/theme';
@@ -32,6 +31,11 @@ const Footer: React.FC = () => {
             href="https://github.com/ifpe-open-source"
             Icon={GithubIcon}
             label="GitHub"
+          />
+          <SocialButton
+            href="https://www.instagram.com/ifpeopensource/"
+            Icon={InstagramIcon}
+            label="Instagram"
           />
           <SocialButton
             href="mailto:contato@ifpeopensource.com.br"


### PR DESCRIPTION
Adiciona o ícone da conta do Instagram ao rodapé da página, junto aos ícones do GitHub e do e-mail.

Foi utilizado o ícone `AiOutlineInstagram` do pacote Ant Design, usando o `react-icons`.

Também foi removida uma importação do `next/link` não utilizada.