### PR TITLE
Evitar saída não intencional pelos links de mídias sociais

### DIFF
--- a/src/components/Footer/SocialButton/index.tsx
+++ b/src/components/Footer/SocialButton/index.tsx
@@ -11,7 +11,7 @@ interface SocialButtonProps {
 
 const SocialButton: React.FC<SocialButtonProps> = ({ Icon, href, label }) => (
   <Link href={href} passHref>
-    <Button aria-label={label}>
+    <Button aria-label={label} target="_blank">
       <Icon size={40} />
     </Button>
   </Link>

--- a/src/components/Footer/SocialButton/index.tsx
+++ b/src/components/Footer/SocialButton/index.tsx
@@ -11,7 +11,7 @@ interface SocialButtonProps {
 
 const SocialButton: React.FC<SocialButtonProps> = ({ Icon, href, label }) => (
   <Link href={href} passHref>
-    <Button aria-label={label} target="_blank">
+    <Button aria-label={label} target="_blank" rel="noopener noreferrer">
       <Icon size={40} />
     </Button>
   </Link>


### PR DESCRIPTION
Adiciona `target="_blank"` ao `Button` do componente `SocialButton` para evitar saída não intencional da página.