### PR TITLE
Corrige problemas no ReadMoreModal

### DIFF
--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -8,7 +8,7 @@ export const Container = styled.div`
 
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: 2;
 
   ${(props) =>
     props.className === 'pageTop' &&

--- a/src/components/WhoWeAre/ReadMoreModal/index.tsx
+++ b/src/components/WhoWeAre/ReadMoreModal/index.tsx
@@ -37,6 +37,7 @@ const ReadMoreModal: React.FC<ModalProps> = ({
       style={{
         overlay: {
           backgroundColor: theme.modalBackground,
+          zIndex: 10,
         },
         content: {
           backgroundColor: theme.body,

--- a/src/components/WhoWeAre/index.tsx
+++ b/src/components/WhoWeAre/index.tsx
@@ -1,11 +1,20 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+
 import Section from '../Section';
 import { Description, Title } from '../../styles/sections';
-import { ReadMoreButton } from './styles';
 import ReadMoreModal from './ReadMoreModal';
+
+import { useScrollBlock } from '../../hooks/useScrollBlock';
+
+import { ReadMoreButton } from './styles';
 
 const WhoWeAre: React.FC = () => {
   const [modal, setModal] = useState(false);
+  const [blockScroll, allowScroll] = useScrollBlock();
+
+  useEffect(() => {
+    modal ? blockScroll(document) : allowScroll(document);
+  }, [modal]);
 
   function toggleModal() {
     setModal(!modal);

--- a/src/hooks/useScrollBlock.ts
+++ b/src/hooks/useScrollBlock.ts
@@ -1,0 +1,54 @@
+import { useRef } from 'react';
+
+/**
+ * Based on https://gist.github.com/reecelucas/2f510e6b8504008deaaa52732202d2da
+ */
+
+export const useScrollBlock = () => {
+  const scrollBlocked = useRef(false);
+
+  const blockScroll = (safeDocument: Document) => {
+    const html = safeDocument.documentElement;
+    const { body } = safeDocument;
+
+    if (!body || !body.style || scrollBlocked.current) return;
+    if (document == undefined) return;
+
+    const scrollBarWidth = window.innerWidth - html.clientWidth;
+    const bodyPaddingRight =
+      parseInt(
+        window.getComputedStyle(body).getPropertyValue('padding-right')
+      ) || 0;
+
+    /**
+     * 1. Fixes a bug in iOS and desktop Safari whereby setting
+     *    `overflow: hidden` on the html/body does not prevent scrolling.
+     * 2. Fixes a bug in desktop Safari where `overflowY` does not prevent
+     *    scroll if an `overflow-x` style is also applied to the body.
+     */
+    html.style.position = 'relative'; /* [1] */
+    html.style.overflow = 'hidden'; /* [2] */
+    body.style.position = 'relative'; /* [1] */
+    body.style.overflow = 'hidden'; /* [2] */
+    body.style.paddingRight = `${bodyPaddingRight + scrollBarWidth}px`;
+
+    scrollBlocked.current = true;
+  };
+
+  const allowScroll = (safeDocument: Document): void => {
+    const html = safeDocument.documentElement;
+    const { body } = safeDocument;
+
+    if (!body || !body.style || !scrollBlocked.current) return;
+
+    html.style.position = '';
+    html.style.overflow = '';
+    body.style.position = '';
+    body.style.overflow = '';
+    body.style.paddingRight = '';
+
+    scrollBlocked.current = false;
+  };
+
+  return [blockScroll, allowScroll];
+};


### PR DESCRIPTION
Corrige o `z-index` do modal e do header, fazendo com que o header não se sobreponha.
Também previne o scroll do body da página quando o modal está aberto.