### PR TITLE
Resolve o tamanho do SVG no Safari

### DIFF
--- a/src/components/Footer/styles.ts
+++ b/src/components/Footer/styles.ts
@@ -27,6 +27,7 @@ export const Content = styled.footer`
 
   & > svg {
     grid-area: Logo;
+    max-width: 100%;
   }
 `;
 


### PR DESCRIPTION
Adiciona mudanças no `styles.ts` do Footer para ajustar o tamanho do svg