### PR TITLE
Corrige propriedades CSS não suportadas em alguns browsers

### DIFF
--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -3,8 +3,13 @@ import styled, { css } from 'styled-components';
 
 export const Container = styled.div`
   background: ${({ theme }) => `${theme.header}CC`};
-  backdrop-filter: blur(10px);
   max-width: 100%;
+
+  backdrop-filter: blur(10px);
+  /* Se o browser não suportar a propriedade backdrop-filter | If the browser does not support backdrop-filter property */
+  @supports not ((-webkit-backdrop-filter: none) or (backdrop-filter: none)) {
+    background: ${({ theme }) => `${theme.header}F5`};
+  }
 
   position: sticky;
   top: 0;
@@ -40,9 +45,15 @@ export const Content = styled.div`
     padding: 16px 16px;
   }
 
+  @supports not (zoom: 1.2) {
+    @media (min-width: 1024px) {
+      height: 5.7rem;
+    }
+  }
+
   /**
-    As propriedades a seguir foram copiadas do tema padrão da biblioteca react-toggle.
-    Para mais informações, veja: https://github.com/aaronshaf/react-toggle
+  As propriedades a seguir foram copiadas do tema padrão da biblioteca react-toggle.
+  Para mais informações, veja: https://github.com/aaronshaf/react-toggle
   */
 
   .react-toggle {
@@ -55,6 +66,10 @@ export const Content = styled.div`
     border: 0;
     padding: 0;
     zoom: 1.3;
+
+    @supports not (zoom: 1.3) {
+      transform: scale(1.3);
+    }
 
     -webkit-touch-callout: none;
     -webkit-user-select: none;
@@ -182,9 +197,15 @@ export const Content = styled.div`
 
 export const Logo = styled.img`
   overflow: visible;
+  transform-origin: top left;
 
   @media (min-width: 1024px) {
     zoom: 1.2;
+
+    /* Se o browser não suportar a propriedade zoom | If the browser does not support zoom property */
+    @supports not (zoom: 1.2) {
+      transform: scale(1.2);
+    }
   }
 
   ${(props) =>
@@ -195,6 +216,10 @@ export const Logo = styled.img`
         top: 3vw !important;
 
         zoom: 2.5;
+        @supports not (zoom: 2.5) {
+          top: 7.5vw !important;
+          transform: scale(2.5);
+        }
       }
     `};
 `;


### PR DESCRIPTION
Adiciona fallback para propriedades CSS não suportadas em alguns browsers, como o Firefox (#41).

- Browser: Firefox Developer Edition 99.0b2 (64-bits)

|   Antes   | Depois |
| --------- | -------- |
![Antes - topo](https://user-images.githubusercontent.com/52381662/158025931-7dd2bee2-529d-4f0d-89d0-47e5689475cb.png) | ![Depois - topo](https://user-images.githubusercontent.com/52381662/158067911-2175380b-6fb7-4ffd-a792-78c8e3246364.png)
![Antes - sticky](https://user-images.githubusercontent.com/52381662/158068087-98e6359d-52d9-4270-8d68-7988f9cab4b0.png) | ![Depois - sticky](https://user-images.githubusercontent.com/52381662/158068103-c031f788-3ff4-4ed4-adae-4f52263dbab8.png)

A propriedade `zoom` não é padrão. Ela pode ser substituída pelo `transform: scale(x);`. No entanto, o resultado não é o mesmo. ([Leia mais](https://developer.mozilla.org/en-US/docs/Web/CSS/zoom)).
Além dela, a propriedade [backdrop-filter](https://developer.mozilla.org/en-US/docs/Web/CSS/backdrop-filter) é experimental.

Para que o resultado nos browsers que suportam as propriedades sejam mantidos, utilizei a at-rule [`@supports`](https://developer.mozilla.org/en-US/docs/Web/CSS/@supports) para adicionar um fallback para essas propriedades.


